### PR TITLE
2d

### DIFF
--- a/examples/camera_2d.rs
+++ b/examples/camera_2d.rs
@@ -1,0 +1,173 @@
+use bevy::{input::mouse::MouseMotion, prelude::*};
+
+use bevy_control::prelude::*;
+
+fn main() {
+    App::new()
+        .add_plugins((DefaultPlugins, CameraPlugin))
+        .add_systems(
+            Startup,
+            (setup_environment, setup_camera_controller, setup_ui),
+        )
+        .add_systems(Update, (update_buffer, move_controller))
+        .add_systems(
+            PostUpdate,
+            switch_view.before(TransformSystem::TransformPropagate),
+        )
+        .run();
+}
+
+fn setup_environment(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    // Add a point light above the scene
+    commands.spawn((PointLight::default(), Transform::from_xyz(0.0, 5.0, 0.0)));
+
+    // Create a shared rectangle mesh that will be reused
+    let rectangle = Rectangle::new(1.0, 1.0);
+    let rectangle_mesh = meshes.add(rectangle);
+
+    // Spawn cubes in a circle
+    let total = 8;
+    let distance = 5.0;
+    for i in 0..total {
+        // Calculate angle for circular placement
+        let n = i as f32 / total as f32;
+        let angle = 2.0 * std::f32::consts::PI * n;
+        commands.spawn((
+            Mesh2d(rectangle_mesh.clone()),
+            MeshMaterial2d(materials.add(Color::BLACK.lighter(n))),
+            // Position cube using trigonometry for circular arrangement
+            Transform::from_xyz(angle.cos() * distance, angle.sin() * distance, i as f32),
+        ));
+    }
+}
+
+fn update_buffer(
+    mut query: Query<&mut DeltaBuffer>,
+    mut mouse: EventReader<MouseMotion>,
+    time: Res<Time>,
+) {
+    for mut delta_buffer in query.iter_mut() {
+        // Calculate total mouse movement this frame
+        let delta = -mouse.read().map(|event| event.delta).sum::<Vec2>();
+
+        // Update input buffer based on mouse movement
+        delta_buffer.update(delta * time.delta_secs());
+    }
+}
+
+const ZOOM_ADJUSTMENT_FACTOR: f32 = 0.01;
+
+fn switch_view(
+    input: Res<ButtonInput<KeyCode>>,
+    mut controllers: Query<(Entity, &mut CameraController2d, &mut DeltaBuffer)>,
+    mut transforms: Query<&mut Transform>,
+    time: Res<Time>,
+) {
+    for (_entity, mut controller, mut delta_buffer) in controllers.iter_mut() {
+        if input.just_pressed(KeyCode::Digit1) {
+            controller.view = CameraView2d::Follow { distance: 1.0 };
+        } else if input.pressed(KeyCode::KeyE) {
+            controller.zoom_by(1.0 + ZOOM_ADJUSTMENT_FACTOR);
+        } else if input.pressed(KeyCode::KeyQ) {
+            controller.zoom_by(1.0 - ZOOM_ADJUSTMENT_FACTOR);
+        } else if input.pressed(KeyCode::Digit8) {
+            // only works if view is manual
+            controller.view = CameraView2d::Manual;
+            // custom panning
+
+            let mut camera_transform = transforms.get_mut(controller.camera).unwrap();
+
+            let delta = controller.get_delta(&mut delta_buffer, time.delta_secs());
+            let translation = camera_transform.rotation * Vec3::new(delta.x, -delta.y, 0.0);
+
+            camera_transform.translation += translation;
+        } else if input.pressed(KeyCode::Digit9) {
+            // only works if view is manual
+            controller.view = CameraView2d::Manual;
+            // custom rotation
+
+            let mut camera_transform = transforms.get_mut(controller.camera).unwrap();
+
+            let delta = controller.get_delta(&mut delta_buffer, time.delta_secs());
+
+            camera_transform.rotate_local_z(delta.y);
+        } else if input.just_pressed(KeyCode::Digit0) {
+            // set to manual to do nothing
+            controller.view = CameraView2d::Manual;
+        } else if controller.view == CameraView2d::Manual {
+            // manually consume all the unused input in the buffer
+            delta_buffer.reset();
+        }
+    }
+}
+
+fn move_controller(
+    input: Res<ButtonInput<KeyCode>>,
+    mut controllers: Query<(&CameraController2d, &mut Transform), Without<Camera2d>>,
+    camera: Query<&Transform, With<Camera2d>>,
+    time: Res<Time>,
+) {
+    for (controller, mut transform) in controllers.iter_mut() {
+        let camera_transform = camera.get(controller.camera).unwrap();
+
+        let mut direction = Vec2::ZERO;
+        if input.pressed(KeyCode::KeyW) || input.pressed(KeyCode::ArrowUp) {
+            direction += Vec2::Y;
+        }
+        if input.pressed(KeyCode::KeyS) || input.pressed(KeyCode::ArrowDown) {
+            direction += Vec2::NEG_Y;
+        }
+        if input.pressed(KeyCode::KeyA) || input.pressed(KeyCode::ArrowLeft) {
+            direction += Vec2::NEG_X;
+        }
+        if input.pressed(KeyCode::KeyD) || input.pressed(KeyCode::ArrowRight) {
+            direction += Vec2::X;
+        }
+
+        let delta = camera_transform.rotation * Vec3::new(direction.x, direction.y, 0.0);
+
+        transform.translation += delta * time.delta_secs();
+    }
+}
+
+fn setup_ui(mut commands: Commands) {
+    commands.spawn(Node::DEFAULT).with_children(|parent| {
+        parent.spawn(Text::new(
+            "Camera Controls:\n\
+                1: Follow View\n\
+                8 (hold): Manual Pan\n\
+                9 (hold): Manual Rotate\n\
+                0: Manual View Mode\n\
+                Q (hold): Zoom in\n\
+                E (hold): Zoom out\n\
+                W/A/S/D or Arrow Keys: Move controller",
+        ));
+    });
+}
+
+fn setup_camera_controller(
+    mut commands: Commands,
+    mut meshes: ResMut<Assets<Mesh>>,
+    mut materials: ResMut<Assets<ColorMaterial>>,
+) {
+    // spawn camera and get entity
+    let camera = commands.spawn(Camera2d::default()).id();
+
+    let rectangle = Rectangle::new(1.0, 1.0);
+    let rectangle_mesh = meshes.add(rectangle);
+
+    let mut entity_commands = commands.spawn((
+        Mesh2d(rectangle_mesh),
+        MeshMaterial2d(materials.add(Color::linear_rgb(0.3, 10.0, 0.3))),
+    ));
+    entity_commands.insert(
+        // add camera controller component
+        CameraController2d::new(camera, CameraView2d::Follow { distance: 1.0 })
+            .with_zoom(10.0)
+            .with_smoothing(0.05),
+    );
+}

--- a/examples/camera_2d.rs
+++ b/examples/camera_2d.rs
@@ -70,9 +70,11 @@ fn switch_view(
     for (_entity, mut controller, mut delta_buffer) in controllers.iter_mut() {
         if input.just_pressed(KeyCode::Digit1) {
             controller.view = CameraView2d::Follow { distance: 1.0 };
-        } else if input.pressed(KeyCode::KeyE) {
-            controller.zoom_by(1.0 + ZOOM_ADJUSTMENT_FACTOR);
         } else if input.pressed(KeyCode::KeyQ) {
+            // zoom in
+            controller.zoom_by(1.0 + ZOOM_ADJUSTMENT_FACTOR);
+        } else if input.pressed(KeyCode::KeyE) {
+            // zoom out
             controller.zoom_by(1.0 - ZOOM_ADJUSTMENT_FACTOR);
         } else if input.pressed(KeyCode::Digit8) {
             // only works if view is manual

--- a/src/camera/controller2d.rs
+++ b/src/camera/controller2d.rs
@@ -1,0 +1,190 @@
+use bevy::prelude::*;
+
+use crate::input::DeltaBuffer;
+
+/// A camera controller component that provides smooth camera movement and rotation
+#[derive(Component)]
+#[require(DeltaBuffer)]
+pub struct CameraController2d {
+    /// Entity ID of the camera being controlled
+    pub camera: Entity,
+    /// View configuration for the camera
+    pub view: CameraView2d,
+    /// Sensitivity of the camera controller
+    pub sensitivity: f32,
+    /// Offset position from the target
+    pub offset: Vec3,
+    /// Rate at which translation decays with smooth interpolation
+    decay_rate: f32,
+    /// Scale multiplier for camera projection
+    scale: f32,
+}
+
+impl CameraController2d {
+    /// Creates a new CameraController instance
+    ///
+    /// # Arguments
+    /// * `camera` - Entity ID of the camera to control
+    /// * `view` - View configuration for the camera
+    pub fn new(camera: Entity, view: CameraView2d) -> Self {
+        Self {
+            camera,
+            view,
+
+            sensitivity: 1.0,
+            offset: Vec3::ZERO,
+
+            decay_rate: f32::INFINITY,
+            scale: 1.0,
+        }
+    }
+
+    /// Sets the sensitivity multiplier for all movement
+    ///
+    /// # Arguments
+    /// * `sensitivity` - Multiplier for camera movement sensitivity
+    #[inline]
+    pub fn with_sensitivity(mut self, sensitivity: f32) -> Self {
+        self.sensitivity = sensitivity;
+        self
+    }
+
+    /// Sets the world space offset from the target position
+    ///
+    /// # Arguments
+    /// * `offset` - 3D vector offset from target position
+    #[inline]
+    pub fn with_offset(mut self, offset: Vec3) -> Self {
+        self.offset = offset;
+        self
+    }
+
+    /// Sets smoothing factor for both translation and rotation.
+    /// Larger values give smoother movement.
+    ///
+    /// # Arguments
+    /// * `smoothing` - Smoothing factor for camera movement
+    #[inline]
+    pub fn with_smoothing(mut self, smoothing: f32) -> Self {
+        let decay_rate = 1.0 / smoothing;
+        self.decay_rate = decay_rate;
+        self
+    }
+
+    /// Sets scale multiplier for camera projection
+    ///
+    /// # Arguments
+    /// * `zoom` - Zoom level for camera projection
+    #[inline]
+    pub fn with_zoom(mut self, zoom: f32) -> Self {
+        self.scale = 1.0 / zoom;
+        self
+    }
+
+    /// Sets scale multiplier for camera projection
+    ///
+    /// # Arguments
+    /// * `zoom` - Zoom level for camera projection
+    #[inline]
+    pub fn set_zoom(&mut self, zoom: f32) {
+        self.scale = 1.0 / zoom;
+    }
+
+    /// Set zoom level for camera projection
+    ///
+    /// # Arguments
+    /// * `zoom` - Zoom level for camera projection
+    #[inline]
+    pub fn zoom_by(&mut self, factor: f32) {
+        self.scale /= factor;
+    }
+
+    /// Gets delta for this frame, with smooth decay
+    /// subtracting the delta from the accumulated delta
+    ///
+    /// # Arguments
+    /// * `dt` - Time elapsed since last update in seconds
+    pub fn get_delta(&mut self, delta_buffer: &mut DeltaBuffer, dt: f32) -> Vec2 {
+        if self.decay_rate.is_finite() {
+            delta_buffer.decay(self.decay_rate, dt) * self.sensitivity
+        } else {
+            delta_buffer.take() * self.sensitivity
+        }
+    }
+}
+
+/// Defines how the camera views its target
+#[derive(PartialEq)]
+pub enum CameraView2d {
+    /// Disables influence over camera. To be handled by another system
+    Manual,
+    /// Camera follows target from a specified distance
+    Follow { distance: f32 },
+}
+
+/// Updates camera position and rotation each frame
+///
+/// # Arguments
+/// * `controller_query` - Query for camera controller components
+/// * `camera_query` - Query for transform components
+/// * `time` - Time resource for frame timing
+/// * `spatial_query` - Spatial query for collision detection (only used with avian3d feature)
+pub(crate) fn update_camera2d(
+    mut controller_query: Query<(&Transform, &mut CameraController2d), Without<Camera2d>>,
+    mut camera_query: Query<(&mut Transform, &mut OrthographicProjection), With<Camera2d>>,
+    time: Res<Time>,
+) {
+    for (controller_transform, controller) in controller_query.iter_mut() {
+        // skip if camera is manually controlled
+        if controller.view == CameraView2d::Manual {
+            continue;
+        }
+        let (mut camera_transform, mut projection) = match camera_query.get_mut(controller.camera) {
+            Ok(components) => components,
+            Err(_) => continue,
+        };
+
+        // get time delta
+        let dt = time.delta_secs();
+
+        // calculate target position with offset
+        let target_translation = controller_transform.translation + controller.offset;
+
+        match &controller.view {
+            CameraView2d::Follow { distance } => {
+                let difference = target_translation - camera_transform.translation;
+
+                // Handle zoom
+
+                if controller.decay_rate.is_finite() {
+                    projection
+                        .scale
+                        .smooth_nudge(&controller.scale, controller.decay_rate, dt);
+                } else {
+                    projection.scale = controller.scale;
+                }
+
+                let current_displacement = difference.xy();
+                let current_distance = current_displacement.length();
+
+                if current_distance == 0.0 {
+                    continue;
+                }
+
+                if current_distance > *distance {
+                    let displacement = if controller.decay_rate.is_finite() {
+                        // apply smoothed translation
+                        let mut new_distance = current_distance;
+                        new_distance.smooth_nudge(distance, controller.decay_rate, dt);
+                        current_displacement * (current_distance - new_distance) / current_distance
+                    } else {
+                        current_displacement * (current_distance - *distance) / current_distance
+                    };
+                    camera_transform.translation.x += displacement.x;
+                    camera_transform.translation.y += displacement.y;
+                }
+            }
+            _ => (),
+        }
+    }
+}

--- a/src/camera/controller2d.rs
+++ b/src/camera/controller2d.rs
@@ -147,22 +147,21 @@ pub(crate) fn update_camera2d(
         // get time delta
         let dt = time.delta_secs();
 
+        // handle zoom
+        if controller.decay_rate.is_finite() {
+            projection
+                .scale
+                .smooth_nudge(&controller.scale, controller.decay_rate, dt);
+        } else {
+            projection.scale = controller.scale;
+        }
+
         // calculate target position with offset
         let target_translation = controller_transform.translation + controller.offset;
 
         match &controller.view {
             CameraView2d::Follow { distance } => {
                 let difference = target_translation - camera_transform.translation;
-
-                // Handle zoom
-
-                if controller.decay_rate.is_finite() {
-                    projection
-                        .scale
-                        .smooth_nudge(&controller.scale, controller.decay_rate, dt);
-                } else {
-                    projection.scale = controller.scale;
-                }
 
                 let current_displacement = difference.xy();
                 let current_distance = current_displacement.length();

--- a/src/camera/mod.rs
+++ b/src/camera/mod.rs
@@ -1,8 +1,13 @@
+#[cfg(feature = "2d")]
+mod controller2d;
 #[cfg(feature = "3d")]
 mod controller3d;
 
 mod plugin;
 
+#[cfg(feature = "2d")]
+pub use controller2d::{CameraController2d, CameraView2d};
 #[cfg(feature = "3d")]
 pub use controller3d::{CameraController3d, CameraView3d};
+
 pub use plugin::CameraPlugin;

--- a/src/camera/plugin.rs
+++ b/src/camera/plugin.rs
@@ -1,5 +1,7 @@
 use bevy::prelude::*;
 
+#[cfg(feature = "2d")]
+use super::controller2d::update_camera2d;
 #[cfg(feature = "3d")]
 use super::controller3d::update_camera3d;
 
@@ -12,6 +14,8 @@ impl Plugin for CameraPlugin {
         app.add_systems(
             PostUpdate,
             (
+                #[cfg(feature = "2d")]
+                update_camera2d.before(TransformSystem::TransformPropagate),
                 #[cfg(feature = "3d")]
                 update_camera3d.before(TransformSystem::TransformPropagate),
             ),


### PR DESCRIPTION
Implemented 2d camera with an example showcasing its implementation. Camera currently enables an entity with CameraController2d to be followed by the camera automatically at a set distance. 

It implements adjusting the scale of the orthographic projection using functions with_zoom, set_zoom and zoom_by.

All movement can be smoothly interpolated by the smooth_nudge function provided by bevy, given that non zero, finite values are input to the with_smoothing function on CameraController2d initialisation.